### PR TITLE
Fix: Use value converter instead of if.bind

### DIFF
--- a/src/home/home.html
+++ b/src/home/home.html
@@ -11,7 +11,7 @@
     <div class="row panel main-panel">
         <div class="col-md-3 panel-vid" css="height:${panel_height}px;" style="overflow:auto;direction:rtl;">
             <ul>
-                <li repeat.for="video of video_list" if.bind="video.type=='youtube'">
+                <li repeat.for="video of video_list | filter:'youtube':'type'">
                     <p>
                         <span class="fr-video fr-fvc fr-draggable fr-dvi" contenteditable="false" draggable="true">
                             <iframe src.bind="video.src" frameborder="0" allowfullscreen="" style="width: 204px; height: 121px;">

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ export function configure(aurelia: Aurelia) {
             config.options.imageDefaultWidth = 100;
             config.options.linkAlwaysBlank = true;
         })
+        .feature('polyfills')
         .feature('resources');
 
     aurelia.use.globalResources('./services/user');

--- a/src/polyfills/index.ts
+++ b/src/polyfills/index.ts
@@ -1,0 +1,5 @@
+import { polyfill as polyfillStringIncludes } from './string.includes';
+
+export function configure() {
+    polyfillStringIncludes();
+}

--- a/src/polyfills/string.includes.ts
+++ b/src/polyfills/string.includes.ts
@@ -1,0 +1,17 @@
+// Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
+export function polyfill() {
+  if (!String.prototype.includes) {
+    String.prototype.includes = function(search, start) {
+      'use strict';
+      if (typeof start !== 'number') {
+        start = 0;
+      }
+      
+      if (start + search.length > this.length) {
+        return false;
+      } else {
+        return this.indexOf(search, start) !== -1;
+      }
+    };
+  }
+}


### PR DESCRIPTION
There were two bugs I found from IE on the home page. First, it was having a hard time with both repeat.for and if.bind on the same element. I hadn't seen this before, but it makes sense that this would confuse IE. Instead, I've achieved the same behavior by using the filter value converter on the repeat.for.

Second, the above strategy threw an error in IE since String.prototype.includes is undefined in IE11. Since this is likely an issue anywhere that the filter value converter is used, I added a new "polyfills" feature and added a string.includes polyfill, taken from the MDN website.

As far as I can tell, the page looks identical in Chrome and IE11:

![1](https://user-images.githubusercontent.com/3845823/36339738-7df1e890-140f-11e8-8963-aa58970179f0.png)
