### PR TITLE
Fix: Replace the new URL() function

### DIFF
--- a/src/members/member-detail.ts
+++ b/src/members/member-detail.ts
@@ -11,6 +11,7 @@ import { StoryWindow } from '../stories/story_window';
 import { MemberEdit } from './member-edit';
 import environment from '../environment';
 import { MemberList } from '../services/member_list';
+import { this_page_url } from '../services/dom_utils';
 
 @autoinject()
 @singleton()
@@ -83,13 +84,10 @@ export class MemberDetail {
                 }
                 this.set_displayed_stories();
             });
+        this.member_url = this_page_url();
     }
 
     bind() {
-        let url = document.URL;
-        let parse = new URL(url);
-        let path = parse.pathname + parse.hash;
-        this.member_url = path;
         console.log("member url ", this.member_url);
     }
 

--- a/src/services/dom_utils.ts
+++ b/src/services/dom_utils.ts
@@ -10,10 +10,11 @@ export function getOffset(el) {
 }
 
 export function this_page_url() {
-  let url = document.URL;
-  let parse = new URL(url);
-  let path = parse.pathname + parse.hash;
-  return path;
+  // INFO [Matt] Removed, as the URL API is not available in IE11.
+  // let url = document.URL;
+  // let parse = new URL(url);
+  // let path = parse.pathname + parse.hash;
+  return `${location.pathname}${location.hash}`;
 }
 
 export function highlight_doesntwork(html: String, keywords: Array<String>) {


### PR DESCRIPTION
The URL API is not supported in IE11, so I have removed its usage throughout the application. I removed its explicit usage in member-detail.ts, and replaced it with the dom_utils function this_page_url(). I rewrote the this_page_url() function to leverage the location API instead, which is widely supported.