### PR TITLE
Feature: Add a "tap and hold" custom element

### DIFF
--- a/src/photos/photos.html
+++ b/src/photos/photos.html
@@ -68,7 +68,7 @@
                     <div class="row" id="photos-container" style="height:560px;overflow:auto;direction:rtl;margin:0;padding:0;margin-bottom:16px;">
                         <span css="padding:0;margin:0;position:relative;width:${photo_size}px;height:${photo_size}px;"
                             repeat.for="photo of photo_list | filter : filter : '*selected' : 'title' | take : 9999">
-                            <a click.trigger="maximize_photo(photo, $event)" class.bind="photo.selected">
+                            <a click.trigger="maximize_photo(photo, $event)" tapandhold="500" longtouch.delegate="toggle_selection(photo)" class.bind="photo.selected" >
                                 <img src="${photo.square_src}" aubs-tooltip="text.bind:photo.title" width="${photo_size}" 
                                     height="${photo_size}" style="margin:0;cursor:pointer;" />
                             </a>

--- a/src/resources/attributes/tapandhold.ts
+++ b/src/resources/attributes/tapandhold.ts
@@ -1,0 +1,39 @@
+import { inject, customAttribute, bindable, bindingMode } from 'aurelia-framework';
+
+@inject(Element)
+@customAttribute('tapandhold')
+export class TapAndHoldCustomAttribute {
+  @bindable({ primaryProperty: true, defaultBindingMode: bindingMode.oneTime }) tolerance = 300;
+  el: Element;
+  ontouchstart: (event) => any;
+  ontouchend: (event) => any;
+  constructor(el) {
+    this.el = el;
+    let timeout = null;
+    let touchstart = null;
+    this.ontouchend = (event) => {
+      let touchend = performance.now();
+      if (touchend - touchstart > this.tolerance) {
+        el.dispatchEvent(new CustomEvent('longclick', { bubbles: true }));
+        event.preventDefault();
+      }
+      touchstart = null;
+      clearTimeout(timeout);
+      el.removeEventListener('touchend', this.ontouchend);
+    }
+    this.ontouchstart = (event) => {
+      touchstart = performance.now();
+      el.addEventListener('touchend', this.ontouchend);
+      timeout = setTimeout(() => {
+        el.dispatchEvent(new CustomEvent('longtouch', { bubbles: true }));
+      }, this.tolerance);
+    }
+  }
+  attached() {
+    this.el.addEventListener('touchstart', this.ontouchstart);
+  }
+  detatched() {
+    this.el.removeEventListener('touchstart', this.ontouchstart);
+    this.el.removeEventListener('touchend', this.ontouchend);
+  }
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,5 +1,6 @@
 export function configure(config) {
   config.globalResources([
+    './attributes/tapandhold',
     './value-converters/filter',
     './value-converters/filter-by-set',
     './value-converters/take',


### PR DESCRIPTION
After looking through the event and interact documentation, I didn't see a good ready-made solution to this problem. The mobile browsers tend to implement a long press behavior to open in a new tab, similar to ctrl+click on a desktop browser, but these are browser internals and not specific events. I've enabled this behavior through the "tapandhold" custom attribute. Adding this attribute will fire two new events, "longtouch" and "longclick". "longtouch" fires when the user taps and holds for x milliseconds. "longclick" fires when the user taps and holds for at least x milliseconds before releasing. The default value for x is 300 milliseconds, but you can customize this by passing a value to the custom attribute, e.g. tapandhold="500". I've added handlers on photos.html to demonstrate.